### PR TITLE
Refactor(doc): matrix description in tutorial_datatypes

### DIFF
--- a/static/doc/master/_sources/tutorial_datatypes.rst.txt
+++ b/static/doc/master/_sources/tutorial_datatypes.rst.txt
@@ -101,8 +101,9 @@ Variants
 The datatype :ref:`variant` belongs to the built-in datatypes of OPC UA and
 is used as a container type. A variant can hold any other datatype as a
 scalar (except variant) or as an array. Array variants can additionally
-denote the dimensionality of the data (e.g. a 2x3 matrix) in an additional
-integer array.
+denote the dimensionality of the data in an additional integer array.
+In the example below, a 3x3 matrix is expressed as a two-dimensional array
+with a length of 3 in each direction.
 
 .. code-block:: c
 


### PR DESCRIPTION
Hopefully made the array dimensions concept a bit clearer given that a 3x3 matrix is encoded.